### PR TITLE
Fix locations in generated code

### DIFF
--- a/lib/ppx_fresh.ml
+++ b/lib/ppx_fresh.ml
@@ -6,8 +6,8 @@ let mapper =
 
     method! expression e =
       match e.pexp_desc with
-      | Pexp_fun (l, opt, pat, e) ->
-          { e with pexp_desc = Pexp_fun (l, opt, pat, self#expression e) }
+      | Pexp_fun (l, opt, pat, ee) ->
+          { e with pexp_desc = Pexp_fun (l, opt, pat, self#expression ee) }
       | Pexp_constraint (ee, t) ->
           { e with pexp_desc = Pexp_constraint (self#expression ee, t) }
       | _ -> super#expression e


### PR DESCRIPTION
There was a simple bug in the `Pexp_fun` case where the body's expression was shadowing the whole fun expression and lead to a faulty location!